### PR TITLE
避免回到顶部功能失效

### DIFF
--- a/XRCarouselView/XRCarouselView.m
+++ b/XRCarouselView/XRCarouselView.m
@@ -93,6 +93,7 @@ static NSString *cache;
 - (UIScrollView *)scrollView {
     if (!_scrollView) {
         _scrollView = [[UIScrollView alloc] init];
+        _scrollView.scrollsToTop = NO;
         _scrollView.pagingEnabled = YES;
         _scrollView.bounces = NO;
         _scrollView.showsHorizontalScrollIndicator = NO;


### PR DESCRIPTION
[fix] 避免页面存在多个 ScrollView 时，点击 Status bar 回到顶部功能失效;
